### PR TITLE
Modify sys.modules during lib-versioning

### DIFF
--- a/tests/utils/test_libversioning.py
+++ b/tests/utils/test_libversioning.py
@@ -12,7 +12,6 @@ def _run_code(code: str, lib_name: str, version: str):
 class LibVersioningTests(unittest.TestCase):
     def test_pandas_1(self):
         #  df.ftypes was removed in Pandas 1.* but was only deprecated in 0.25.0
-        #  NOTE: This tests does not pass when run with PyCharm
         code = (
             "import sys; print(sys.path)\n"
             "import pandas as pd\n"
@@ -24,7 +23,6 @@ class LibVersioningTests(unittest.TestCase):
 
     def test_pandas_2(self):
         #  df.ftypes was removed in Pandas 1.* but was only deprecated in 0.25.0
-        #  NOTE: This tests does not pass when run with PyCharm
         code = (
             "import sys; print(sys.path)\n"
             "import pandas as pd\n"


### PR DESCRIPTION
This increases the reliability of the entire process as it forces the deletion of any pre-loaded modules that can cause failure. This also helps get rid of the bug in PyCharm - now the tests pass within PyCharm's environment.

This builds on #12 and resolves #9 better